### PR TITLE
Try to stop losing and re-adding devices

### DIFF
--- a/src/homie/mod.rs
+++ b/src/homie/mod.rs
@@ -132,7 +132,7 @@ async fn handle_homie_event(
             if controller
                 .devices()
                 .values()
-                .all(|device| device.has_required_attributes())
+                .all(|device| device.has_required_attributes() && !device.nodes.is_empty())
             {
                 tracing::trace!("Homie event {:?}, requesting sync.", event);
                 request_sync.execute();

--- a/src/ratelimit.rs
+++ b/src/ratelimit.rs
@@ -36,12 +36,10 @@ impl RateLimiter {
         Self { notify, handle }
     }
 
-    /// Calls the callback, either immediately or after waiting enough time.
+    /// Calls the callback after waiting for the period.
     ///
-    /// If the callback has not been called for at least the period of the rate limiter, calls it
-    /// immediately. If it has, then waits until the period has elapsed since the last time it was
-    /// called. If `execute` is called multiple times within the period the callback will still only
-    /// be called once.
+    /// If `execute` is called multiple times within the period the callback will still only be
+    /// called at most twice.
     pub fn execute(&self) {
         self.notify.notify_one();
     }
@@ -60,7 +58,7 @@ async fn callback_run_loop(
 ) {
     loop {
         notify.notified().await;
-        callback().await;
         time::sleep(period).await;
+        callback().await;
     }
 }


### PR DESCRIPTION
Be more cautious about requesting sync, and return an error in response to sync if devices aren't ready.